### PR TITLE
Dogkat update and bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 [//]: # ()
 [//]: # (### Deprecated/Removed)
 
+## [ 2024/03/15 - 0.1.5 ]
+
+## Changed/Added
+* Updated dogkat
+* Removed a reference to sha256 in the postgres tag as it's supplied in the repo line
+
 ## [ 2024/03/15 - 0.1.4 ]
 
 ## Changed/Added

--- a/scripts/dogkat.yaml
+++ b/scripts/dogkat.yaml
@@ -1,5 +1,5 @@
 chart:
-  version: 0.1.7
+  version: 0.1.8
 metrics:
   enabled: false
   pushGatewayURI: http://prometheus-push-gateway.prometheus:9091
@@ -23,7 +23,7 @@ core:
 postgres:
   image:
     repo: registry.infra.poc.dev.nscale.com/docker-cache/postgres@sha256
-    tag: sha256:49fd8c13fbd0eb92572df9884ca41882a036beac0f12e520274be85e7e7806e9 # 16.2-alpine
+    tag: 49fd8c13fbd0eb92572df9884ca41882a036beac0f12e520274be85e7e7806e9 # 16.2-alpine
 ingress:
   enabled: true
   ingressClassName: nginx


### PR DESCRIPTION
* Updated dogkat
* Removed a buggy reference to sha256 in the tag line of the postgres image as the repo line has it

# PR checklist
- [x] Tested Dockerfile Locally
- [x] Updated Changelog
- [ ] Updated Readme (where required)
